### PR TITLE
Minor fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         run: go mod download
 
       - name: Build
-        run: make bin
+        run: make ${{ matrix.platform }}
 
       - name: Upload
         id: upload-release-asset

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ GO_BUILD_COMMAND=go build -i -installsuffix cgo -ldflags="-s -w -X main.version=
 
 .PHONY: all lint bin clean
 
+all: lint bin  ## Lint and build binaries
+	@echo Done.
 
 linux: $(LINUX_BIN_NAME)  ## Build binary for linux
 
@@ -50,10 +52,8 @@ lint:  ## Lint
 		--exclude="comment on" \
 		--exclude="error should be the last" \
 		--exclude="should have comment" \
-		./pkg/...
-	@echo Done.
-
-all: lint bin  ## Lint and build binaries
+		./pkg/... \
+		./cmd/...
 	@echo Done.
 
 clean:  ## Clean previously built binaries

--- a/pkg/loggerus/jsonformatter.go
+++ b/pkg/loggerus/jsonformatter.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/nuclio/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -91,9 +92,8 @@ func (f *JSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	data["ctx"] = ctx
 
 	serialized, err := json.Marshal(data)
-
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal fields to JSON, %v", err)
+		return nil, errors.Wrap(err, "Failed to marshal fields to JSON")
 	}
 
 	// we append the rune (byte) '\n' rather than the string "\n"


### PR DESCRIPTION
- when running make w/o target, default to `all`
- lint `cmd` dir as well
- release action should compile binary per matrixed platform
